### PR TITLE
fix #1

### DIFF
--- a/lib/Capture/DesktopStreamCapture.js
+++ b/lib/Capture/DesktopStreamCapture.js
@@ -51,7 +51,11 @@
             that.stream = stream;
             var video = document.createElement('video');
             that.video = video;
-            video.src = window.URL.createObjectURL(stream);
+            if ('srcObject' in video) {
+              video.srcObject = stream;
+            } else {
+              video.src = URL.createObjectURL(stream);
+            }
             video.addEventListener('canplay',function(event){
               deferred.resolve();
             });
@@ -94,7 +98,7 @@
   };
   
   DesktopStreamCapture.prototype._onDone = function(){
-    if(this.stream)this.stream.stop();
+    if(this.stream)this.stream.getTracks().forEach(track => {track.stop()});
     return TabCapture.prototype._onDone.apply(this);
   };
   

--- a/lib/Capture/TabStreamCapture.js
+++ b/lib/Capture/TabStreamCapture.js
@@ -47,7 +47,11 @@
           that.stream = stream;
           var video = document.createElement('video');
           that.video = video;
-          video.src = window.URL.createObjectURL(stream);
+          if ('srcObject' in video) {
+            video.srcObject = stream;
+          } else {
+            video.src = URL.createObjectURL(stream);
+          }
           video.addEventListener('canplay',function(event){
             deferred.resolve();
           });
@@ -89,7 +93,7 @@
   };
   
   TabStreamCapture.prototype._onDone = function(){
-    if(this.stream)this.stream.stop();
+    if(this.stream)this.stream.getTracks().forEach(track => {track.stop()});
     return TabCapture.prototype._onDone.apply(this);
   };
   


### PR DESCRIPTION
- use HTMLMedia​Element​.src​Object instead of URL.createObjectURL()
- call MediaStreamTrack.stop() on Done